### PR TITLE
chore: update linter rules to lints/recommended.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 analyzer:
   exclude:
-    - lib/**/*.bp*.dart
+    - lib/src/protos

--- a/lib/src/connection/connection.dart
+++ b/lib/src/connection/connection.dart
@@ -48,7 +48,7 @@ class Connection {
   /// The state should be persisted after every method call as all of them
   /// modify the state.
   Uint8List getState() {
-    _connectionState.beginOperation(Operation.ExportState);
+    _connectionState.beginOperation(Operation.exportState);
     // Operation can be completed directly, as is it does not modify the state.
     // Therefore, no rollback is needed, even if there is an error.
     _connectionState.completeOperation();
@@ -56,7 +56,7 @@ class Connection {
   }
 
   void setOutgoingEncryptionAlgorithm(Algorithm algorithm) {
-    _connectionState.beginOperation(Operation.UpdateConnectionSettings);
+    _connectionState.beginOperation(Operation.updateConnectionSettings);
     try {
       _stateAccessor.outgoingEncryptionAlgorithm = algorithm;
       _connectionState.completeOperation();
@@ -69,7 +69,7 @@ class Connection {
   /// Creates a new connection request.
   /// This is the first step of the handshake.
   Future<HandshakeMessage> createConnectionRequest() async {
-    _connectionState.beginOperation(Operation.CreateConnectionOffer);
+    _connectionState.beginOperation(Operation.createConnectionOffer);
     try {
       final p = await _handshake.createConnectionRequest(
           algorithm: _stateAccessor.outgoingEncryptionAlgorithm);
@@ -87,7 +87,7 @@ class Connection {
   /// The device is then ready to encrypt and decrypt messages.
   Future<HandshakeMessage> applyConnectionRequest(Uint8List welcomeMessage,
       {required SecretKey remoteKey}) async {
-    _connectionState.beginOperation(Operation.ApplyConnectionOffer);
+    _connectionState.beginOperation(Operation.applyConnectionOffer);
     try {
       final p = await _handshake.applyConnectionRequest(welcomeMessage,
           remoteKey: remoteKey,
@@ -105,7 +105,7 @@ class Connection {
   /// The device is then ready to encrypt and decrypt messages.
   Future<void> applyConnectionConfirmation(Uint8List connectionConfirmation,
       {required SecretKey remoteKey}) async {
-    _connectionState.beginOperation(Operation.ApplyConnectionConfirmation);
+    _connectionState.beginOperation(Operation.applyConnectionConfirmation);
     try {
       final p = await _handshake.applyConnectionConfirmation(
           connectionConfirmation,
@@ -120,7 +120,7 @@ class Connection {
 
   /// Decrypts an incoming message.
   Future<Uint8List> decrypt(Uint8List message) async {
-    _connectionState.beginOperation(Operation.DecryptMessage);
+    _connectionState.beginOperation(Operation.decryptMessage);
     try {
       final p = await _encryption.decrypt(message);
       _connectionState.completeOperation();
@@ -133,7 +133,7 @@ class Connection {
 
   /// Encrypts an outgoing message.
   Future<Uint8List> encrypt(Uint8List plaintext) async {
-    _connectionState.beginOperation(Operation.EncryptMessage);
+    _connectionState.beginOperation(Operation.encryptMessage);
     try {
       final p = await _encryption.encrypt(plaintext,
           algorithm: _stateAccessor.outgoingEncryptionAlgorithm);

--- a/lib/src/parallelism/exception.dart
+++ b/lib/src/parallelism/exception.dart
@@ -7,19 +7,19 @@ export 'package:endguard/src/protos/protocol.pb.dart'
 
 String _operationDescription(Operation op) {
   switch (op) {
-    case Operation.ExportState:
+    case Operation.exportState:
       return 'export the connection state';
-    case Operation.UpdateConnectionSettings:
+    case Operation.updateConnectionSettings:
       return 'update the settings for the connection';
-    case Operation.CreateConnectionOffer:
+    case Operation.createConnectionOffer:
       return 'create a new ConnectionOffer';
-    case Operation.ApplyConnectionOffer:
+    case Operation.applyConnectionOffer:
       return 'apply a ConnectionOffer';
-    case Operation.ApplyConnectionConfirmation:
+    case Operation.applyConnectionConfirmation:
       return 'apply a ConnectionConfirmation';
-    case Operation.EncryptMessage:
+    case Operation.encryptMessage:
       return 'encrypt a message';
-    case Operation.DecryptMessage:
+    case Operation.decryptMessage:
       return 'decrypt a message';
     default:
       return '<unknown operation>';

--- a/lib/src/parallelism/manager.dart
+++ b/lib/src/parallelism/manager.dart
@@ -47,23 +47,23 @@ class ParallelismManager {
   /// An Error is thrown if beginOperation is called before the previous operation was completed with completeOperation() or abortOperation().
   void beginOperation(Operation o) {
     final currentState = _stateAccessor.initializationState;
-    if (o == Operation.ExportState) {
+    if (o == Operation.exportState) {
       _beginOperation(o);
-    } else if (o == Operation.UpdateConnectionSettings) {
+    } else if (o == Operation.updateConnectionSettings) {
       _beginOperation(o);
-    } else if (o == Operation.CreateConnectionOffer &&
+    } else if (o == Operation.createConnectionOffer &&
         currentState == ConnectionState_State.NOT_INITIALIZED) {
       _beginOperation(o);
-    } else if (o == Operation.ApplyConnectionOffer &&
+    } else if (o == Operation.applyConnectionOffer &&
         currentState == ConnectionState_State.NOT_INITIALIZED) {
       _beginOperation(o);
-    } else if (o == Operation.ApplyConnectionConfirmation &&
+    } else if (o == Operation.applyConnectionConfirmation &&
         currentState == ConnectionState_State.HANDSHAKE) {
       _beginOperation(o);
-    } else if (o == Operation.EncryptMessage &&
+    } else if (o == Operation.encryptMessage &&
         currentState == ConnectionState_State.ESTABLISHED) {
       _beginOperation(o);
-    } else if (o == Operation.DecryptMessage &&
+    } else if (o == Operation.decryptMessage &&
         currentState == ConnectionState_State.ESTABLISHED) {
       _beginOperation(o);
     } else {
@@ -81,11 +81,11 @@ class ParallelismManager {
   void completeOperation() {
     var o = _activeOperation;
 
-    if (o == Operation.CreateConnectionOffer) {
+    if (o == Operation.createConnectionOffer) {
       _stateAccessor.initializationState = ConnectionState_State.HANDSHAKE;
-    } else if (o == Operation.ApplyConnectionOffer) {
+    } else if (o == Operation.applyConnectionOffer) {
       _stateAccessor.initializationState = ConnectionState_State.ESTABLISHED;
-    } else if (o == Operation.ApplyConnectionConfirmation) {
+    } else if (o == Operation.applyConnectionConfirmation) {
       _stateAccessor.initializationState = ConnectionState_State.ESTABLISHED;
     }
 

--- a/lib/src/parallelism/operations.dart
+++ b/lib/src/parallelism/operations.dart
@@ -1,9 +1,9 @@
 enum Operation {
-  ApplyConnectionConfirmation,
-  ApplyConnectionOffer,
-  CreateConnectionOffer,
-  DecryptMessage,
-  EncryptMessage,
-  ExportState,
-  UpdateConnectionSettings,
+  applyConnectionConfirmation,
+  applyConnectionOffer,
+  createConnectionOffer,
+  decryptMessage,
+  encryptMessage,
+  exportState,
+  updateConnectionSettings,
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  lints:
+    dependency: "direct dev"
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:
@@ -191,7 +198,7 @@ packages:
     source: hosted
     version: "1.8.0"
   pedantic:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ homepage: https://github.com/robojones/endguard
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
+  lints: ^1.0.1
   test: ^1.17.10
-  pedantic: ^1.11.1
 dependencies:
   cryptography: ^2.0.2
   protobuf: ^2.0.0


### PR DESCRIPTION
The previously used "pedantic" linter config was deprecated and superseded by the "lints" package.