### PR TITLE
feat(connection): add support for additional authenticated data

### DIFF
--- a/lib/src/crypto/handshake_encryption.dart
+++ b/lib/src/crypto/handshake_encryption.dart
@@ -14,8 +14,10 @@ final sha = Sha256();
 /// as key.
 class HandshakeEncryption {
   /// Generates the SHA256 hash of the [plaintext].
-  static Future<SecretKeyData> _hashSHA256(Uint8List plaintext) async {
-    final hash = await sha.hash(plaintext);
+  static Future<SecretKeyData> _hashSHA256(Uint8List plaintext,
+      {required Uint8List? aad}) async {
+    aad ??= Uint8List(0);
+    final hash = await sha.hash(aad + plaintext);
     final key = SecretKeyData(hash.bytes);
     return key;
   }
@@ -23,8 +25,9 @@ class HandshakeEncryption {
   /// Validates that the [key] actually equals the SHA256 hash of the [plaintext].
   static Future<void> _validatePackage(Uint8List plaintext,
       {required SecretKey key,
-      required Uint8List encryptedMessage}) async {
-    final checksum = await _hashSHA256(plaintext);
+      required Uint8List encryptedMessage,
+      required Uint8List? aad}) async {
+    final checksum = await _hashSHA256(plaintext, aad: aad);
     if (checksum != key) {
       throw MessageAuthenticationException(encryptedMessage: encryptedMessage);
     }
@@ -32,10 +35,10 @@ class HandshakeEncryption {
 
   /// Encrypts a [message] using its SHA256 hash as key.
   static Future<HandshakeMessage> encryptMessage(Uint8List message,
-      {required Algorithm algorithm}) async {
-    final key = await _hashSHA256(message);
-    final e =
-        await MessageEncryption.encrypt(message, key, algorithm: algorithm);
+      {required Algorithm algorithm, required Uint8List? aad}) async {
+    final key = await _hashSHA256(message, aad: aad);
+    final e = await MessageEncryption.encrypt(message, key,
+        algorithm: algorithm, aad: aad);
     final bytes = e.writeToBuffer();
 
     return HandshakeMessage(bytes, key: key);
@@ -43,10 +46,10 @@ class HandshakeEncryption {
 
   /// Decrypts an encrypted [message] using the [key].
   static Future<Uint8List> decryptMessage(Uint8List message,
-      {required SecretKey key}) async {
-
-    final bytes = await MessageEncryption.decrypt(message, key);
-    await _validatePackage(bytes, key: key, encryptedMessage: message);
+      {required SecretKey key, required Uint8List? aad}) async {
+    final bytes = await MessageEncryption.decrypt(message, key, aad: aad);
+    await _validatePackage(bytes,
+        key: key, encryptedMessage: message, aad: aad);
     return bytes;
   }
 }

--- a/lib/src/transmission/transmission.dart
+++ b/lib/src/transmission/transmission.dart
@@ -30,10 +30,12 @@ class Transmission {
         diffieHellmanRatchetValue.bytes + sha256RatchetValue.bytes);
   }
 
-  Future<Uint8List> decrypt(Uint8List message) async {
+  Future<Uint8List> decrypt(Uint8List message,
+      {required Uint8List? aad}) async {
     // decrypt
     final keyMaterial = await _gatherDecryptionKeyMaterial();
-    final envelopeBytes = await MessageEncryption.decrypt(message, keyMaterial);
+    final envelopeBytes =
+        await MessageEncryption.decrypt(message, keyMaterial, aad: aad);
     final envelope = Envelope.fromBuffer(envelopeBytes);
 
     // advance ratchets
@@ -48,7 +50,8 @@ class Transmission {
     return Uint8List.fromList(envelope.payload);
   }
 
-  Future<Uint8List> encrypt(Uint8List plaintext, {required Algorithm algorithm}) async {
+  Future<Uint8List> encrypt(Uint8List plaintext,
+      {required Algorithm algorithm, required Uint8List? aad}) async {
     // create envelope
     final localKeyPair =
         await _diffieHellmanRatchet.generateAndAddLocalDiffieHellmanKeyPair();
@@ -63,7 +66,7 @@ class Transmission {
     // encrypt
     final keyMaterial = await _gatherEncryptionKeyMaterial();
     final e = await MessageEncryption.encrypt(envelopeBytes, keyMaterial,
-        algorithm: algorithm);
+        algorithm: algorithm, aad: aad);
 
     // advance ratchets
     await _diffieHellmanRatchet.advanceOutgoingDiffieHellmanRatchet();

--- a/test/end_to_end_test.dart
+++ b/test/end_to_end_test.dart
@@ -84,7 +84,7 @@ void main() {
           });
 
           test(
-              'messages should be able to be encrypted by one instance and encrypted by the other',
+              'messages should be able to be encrypted by one instance and decrypted by the other',
               () async {
             final a = Connection();
             final b = Connection();
@@ -127,6 +127,75 @@ void main() {
             await testSendMessage(
                 sender: a, recipient: b, message: 'message from a to b');
           });
+        });
+
+        test(
+            'additional authentication data should be authenticated alongside the message',
+            () async {
+          // Some additional authenticated data for the handshake
+          final crAad =
+              Uint8List.fromList(utf8.encode('connection request aad'));
+          final ccAad =
+              Uint8List.fromList(utf8.encode('connection confirmation aad'));
+
+          final a = Connection();
+          final b = Connection();
+
+          if (algorithmA != null) {
+            a.setOutgoingEncryptionAlgorithm(algorithmA);
+          }
+          if (algorithmB != null) {
+            b.setOutgoingEncryptionAlgorithm(algorithmB);
+          }
+
+          // handshake
+          final connectionRequest = await a.createConnectionRequest(aad: crAad);
+          final connectionConfirmation = await b.applyConnectionRequest(
+              connectionRequest.exportPackage(),
+              remoteKey: connectionRequest.exportKey(),
+              requestAad: crAad,
+              aad: ccAad);
+          await a.applyConnectionConfirmation(
+              connectionConfirmation.exportPackage(),
+              remoteKey: connectionConfirmation.exportKey(),
+              aad: ccAad);
+
+          Future<void> testSendMessage({
+            required Connection sender,
+            required Connection recipient,
+            required String message,
+            required String aad,
+          }) async {
+            final m = Uint8List.fromList(utf8.encode(message));
+            final data = Uint8List.fromList(utf8.encode(aad));
+            final encrypted = await sender.encrypt(m, aad: data);
+            final result = await recipient.decrypt(encrypted, aad: data);
+
+            expect(result.length, equals(m.length));
+            expect(result, equals(m));
+          }
+
+          await testSendMessage(
+              sender: a,
+              recipient: b,
+              message: 'message from a to b',
+              aad: 'basically random data to be authenticated alongside the message');
+          await testSendMessage(
+              sender: b,
+              recipient: a,
+              message: 'message from b to a',
+              aad: 'a different aad');
+          await testSendMessage(
+              sender: b,
+              recipient: a,
+              message: 'message from b to a',
+              aad:
+                  'aad for another message');
+          await testSendMessage(
+              sender: a,
+              recipient: b,
+              message: 'message from a to b',
+              aad: 'and some more data');
         });
       }
     }

--- a/test/end_to_end_test.dart
+++ b/test/end_to_end_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:endguard/endguard.dart';
-import 'package:endguard/src/protos/protocol.pb.dart';
 import 'package:endguard/src/state/state_accessor.dart';
 import 'package:test/test.dart';
 
@@ -179,7 +178,8 @@ void main() {
               sender: a,
               recipient: b,
               message: 'message from a to b',
-              aad: 'basically random data to be authenticated alongside the message');
+              aad:
+                  'basically random data to be authenticated alongside the message');
           await testSendMessage(
               sender: b,
               recipient: a,
@@ -189,8 +189,7 @@ void main() {
               sender: b,
               recipient: a,
               message: 'message from b to a',
-              aad:
-                  'aad for another message');
+              aad: 'aad for another message');
           await testSendMessage(
               sender: a,
               recipient: b,

--- a/test/test_context_test.dart
+++ b/test/test_context_test.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+
+import 'test_context.dart';
+
+void main() {
+  group('connection context:', () {
+    test('the connection request package can be applied to an uninitialized connection', () async {
+      final context = TestContext();
+
+      final cr = await context.connectionRequest;
+      final a = context.uninitializedConnection;
+
+      await a.applyConnectionRequest(cr.exportPackage(), remoteKey: cr.exportKey());
+    });
+
+    test('the connection confirmation package can be applied to a connection in handshake state', () async {
+      final context = TestContext();
+
+      final cc = await context.connectionConfirmation;
+      final a = await context.handshakeStateConnection;
+
+      await a.applyConnectionConfirmation(cc.exportPackage(), remoteKey: cc.exportKey());
+    });
+
+    test('the testMessage can be decrypted by the established connection', () async {
+      final context = TestContext();
+
+      final testMessage = await context.testMessage;
+      final testAad = context.testAad;
+      final a = await context.establishedConnection;
+
+      await a.decrypt(testMessage, aad: testAad);
+    });
+  });
+}


### PR DESCRIPTION
### Issues
- resolves #18

### TODO
- [x] add support for aad to `createConnectionRequest`, `applyConnectionRequest`, `applyConnectionConfirmation`, `encrypt` and `decrypt`
- [x] add tests to verify that the aad is actually authenticated